### PR TITLE
[ANSI] - String types length support

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,55 @@
+<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->
+
+## Pull request checklist
+
+Please check if your PR fulfills the following requirements:
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
+- [ ] Tests (`cargo test`) were run locally and any failures were fixed
+- [ ] Clippy (`cargo +stable clippy --all-targets --all-features`) has passed locally and any fixes 
+  were made for failures
+- [ ] Format (`cargo +nightly fmt --all`) was run locally 
+
+
+## Pull request type
+
+<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
+
+<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
+
+Please check the type of change your PR introduces:
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, renaming)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] Documentation content changes
+- [ ] Other (please describe):
+
+
+## What is the current behavior?
+<!-- Please describe the current behavior that you are modifying. -->
+
+
+<!-- Issues are required for both bug fixes and features. -->
+Issue URL:
+
+
+## What is the new behavior?
+<!-- Please describe the behavior or changes that are being added by this PR. -->
+
+-
+-
+-
+
+## Does this introduce a breaking change?
+
+- [ ] Yes
+- [ ] No
+
+<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
+
+
+## Other information
+
+<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //! dialect-specific implementations, instead of using the way too genetic
 //! implementation from the parser library.
 
+extern crate core;
+
 /// AST structures and functions for `ANSI` data type.
 ///
 /// Based on documentation from ANSI standard 2016 [(1)].


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests (`cargo test`) were run locally and any failures were fixed
- [X] Clippy (`cargo +stable clippy --all-targets --all-features`) has passed locally and any fixes 
  were made for failures
- [X] Format (`cargo +nightly fmt --all`) was run locally 


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, we can only support string types without precision information.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: None


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The following data types now have a new syntax supported:
```doc
CHARACTER [(<length> <char length units>)]
CHAR [(<length> <char length units>)]
CHARACTER VARYING [(<length> <char length units>)]
CHAR VARYING [(<length> <char length units>)]
VARCHAR [(<length> <char length units>)]

Where
<length> = unsigned integer
<char length units> = OCTETS | CHARACTERS
```
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Reference: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#char-length-units