### PR TITLE
fix: fixing some wrong parses, and optimizing others

### DIFF
--- a/src/ansi/data_type_structures/ast.rs
+++ b/src/ansi/data_type_structures/ast.rs
@@ -242,8 +242,8 @@ impl CharacterLength {
         }
     }
 
-    pub fn with_units(&mut self, opt_units: Option<CharacterLengthUnits>) -> &mut Self {
-        self.opt_units = opt_units;
+    pub fn with_units(&mut self, units: CharacterLengthUnits) -> &mut Self {
+        self.opt_units = Some(units);
         self
     }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests (`cargo test`) were run locally and any failures were fixed
- [X] Clippy (`cargo +stable clippy --all-targets --all-features`) has passed locally and any fixes 
  were made for failures
- [X] Format (`cargo +nightly fmt --all`) was run locally 


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, we accept a lot of non-spaced things wrongly. Ex: `CREATESCHEMA`

<!-- Issues are required for both bug fixes and features. -->
Issue URL: None


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now the queries have correct spacing validation.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
