### PR TITLE
feat: add support for referential actions

### DIFF
--- a/src/ansi/ast/common.rs
+++ b/src/ansi/ast/common.rs
@@ -1,6 +1,7 @@
+use std::fmt;
+
 use crate::ansi::ast::data_types::DataType;
 use crate::common::Ident;
-use std::fmt;
 
 /// Qualified or unqualified identifier representing a schema.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -70,6 +71,30 @@ pub enum DropBehavior {
     Cascade,
     /// RESTRICT - the drop is restricted to the specific structure.
     Restrict,
+}
+
+/// Referential action.
+///
+/// # Supported syntax
+/// ```plaintext
+///   CASCADE
+/// | SET NULL
+/// | SET DEFAULT
+/// | RESTRICT
+/// | NO ACTION
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum ReferentialAction {
+    /// `CASCADE`.
+    Cascade,
+    /// `SET NULL`.
+    SetNull,
+    /// `SET DEFAULT`.
+    SetDefault,
+    /// `RESTRICT`.
+    Restrict,
+    /// `NO ACTION`.
+    NoAction,
 }
 
 impl SchemaName {
@@ -206,6 +231,20 @@ impl fmt::Display for DropBehavior {
             Self::Restrict => {
                 write!(f, "RESTRICT")?;
             }
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for ReferentialAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cascade => write!(f, "CASCADE")?,
+            Self::SetNull => write!(f, "SET NULL")?,
+            Self::SetDefault => write!(f, "SET DEFAULT")?,
+            Self::Restrict => write!(f, "RESTRICT")?,
+            Self::NoAction => write!(f, "NO ACTION")?,
         }
 
         Ok(())


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests (`cargo test`) were run locally and any failures were fixed
- [X] Clippy (`cargo +stable clippy --all-targets --all-features`) has passed locally and any fixes 
  were made for failures
- [X] Format (`cargo +nightly fmt --all`) was run locally 


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, we do not support referential actions.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #22 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Now, [`<referential action>`](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#referential-action) clauses are supported.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
