### PR TITLE
feat: add support for on delete clause

### DIFF
--- a/src/ansi/ast/common.rs
+++ b/src/ansi/ast/common.rs
@@ -97,6 +97,17 @@ pub enum ReferentialAction {
     NoAction,
 }
 
+/// Delete rule.
+///
+/// # Supported syntax
+/// ```plaintext
+/// ON DELETE <referential action>
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct DeleteRule {
+    referential_action: ReferentialAction,
+}
+
 impl SchemaName {
     #[must_use]
     pub fn new(opt_catalog_name: Option<&Ident>, name: &Ident) -> Self {
@@ -247,6 +258,25 @@ impl fmt::Display for ReferentialAction {
             Self::NoAction => write!(f, "NO ACTION")?,
         }
 
+        Ok(())
+    }
+}
+
+impl DeleteRule {
+    #[must_use]
+    pub fn new(referential_action: ReferentialAction) -> Self {
+        Self { referential_action }
+    }
+
+    #[must_use]
+    pub fn referential_action(&self) -> ReferentialAction {
+        self.referential_action
+    }
+}
+
+impl fmt::Display for DeleteRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ON DELETE {}", self.referential_action())?;
         Ok(())
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests (`cargo test`) were run locally and any failures were fixed
- [X] Clippy (`cargo +stable clippy --all-targets --all-features`) has passed locally and any fixes 
  were made for failures
- [X] Format (`cargo +nightly fmt --all`) was run locally 


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, the `ON DELETE` clause is not supported.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #22 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now, the [on-delete](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#delete-rule) clause is supported.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
