### PR TITLE
feat: support referential triggered actions

### DIFF
--- a/src/ansi/ast/common.rs
+++ b/src/ansi/ast/common.rs
@@ -119,6 +119,21 @@ pub struct UpdateRule {
     referential_action: ReferentialAction,
 }
 
+/// Referential triggered action.
+///
+/// # Supported syntax
+/// ```plaintext
+///   <update rule> [<delete rule>]
+/// | <delete rule> [<update rule>]
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum ReferentialTriggeredAction {
+    /// `<update rule> [<delete rule>]`.
+    UpdateFirst(UpdateRule, Option<DeleteRule>),
+    /// `<delete rule> [<update rule>]`.
+    DeleteFirst(DeleteRule, Option<UpdateRule>),
+}
+
 impl SchemaName {
     #[must_use]
     pub fn new(opt_catalog_name: Option<&Ident>, name: &Ident) -> Self {
@@ -307,6 +322,29 @@ impl UpdateRule {
 impl fmt::Display for UpdateRule {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ON UPDATE {}", self.referential_action())?;
+        Ok(())
+    }
+}
+
+impl fmt::Display for ReferentialTriggeredAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UpdateFirst(update, opt_delete) => {
+                write!(f, "{update}")?;
+
+                if let Some(delete) = opt_delete {
+                    write!(f, " {delete}")?;
+                }
+            }
+            Self::DeleteFirst(delete, opt_update) => {
+                write!(f, "{delete}")?;
+
+                if let Some(update) = opt_update {
+                    write!(f, " {update}")?;
+                }
+            }
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests (`cargo test`) were run locally and any failures were fixed
- [X] Clippy (`cargo +stable clippy --all-targets --all-features`) has passed locally and any fixes 
  were made for failures
- [X] Format (`cargo +nightly fmt --all`) was run locally 


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, referential triggered actions are now supported

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #22 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now, referential triggered actions are supported, following [ANSI syntax](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#referential-triggered-action)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
