### PR TITLE
feat: add match type parsing support

### DIFF
--- a/src/ansi/ast/common.rs
+++ b/src/ansi/ast/common.rs
@@ -134,6 +134,24 @@ pub enum ReferentialTriggeredAction {
     DeleteFirst(DeleteRule, Option<UpdateRule>),
 }
 
+/// Referential action match type.
+///
+/// # Supported syntax
+/// ```plaintext
+///   FULL
+/// | PARTIAL
+/// | SIMPLE
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum MatchType {
+    /// `FULL`.
+    Full,
+    /// `PARTIAL`.
+    Partial,
+    /// `SIMPLE`.
+    Simple,
+}
+
 impl SchemaName {
     #[must_use]
     pub fn new(opt_catalog_name: Option<&Ident>, name: &Ident) -> Self {
@@ -345,6 +363,17 @@ impl fmt::Display for ReferentialTriggeredAction {
             }
         }
 
+        Ok(())
+    }
+}
+
+impl fmt::Display for MatchType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Full => write!(f, "FULL")?,
+            Self::Partial => write!(f, "PARTIAL")?,
+            Self::Simple => write!(f, "SIMPLE")?,
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests (`cargo test`) were run locally and any failures were fixed
- [X] Clippy (`cargo +stable clippy --all-targets --all-features`) has passed locally and any fixes 
  were made for failures
- [X] Format (`cargo +nightly fmt --all`) was run locally 


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
No current behavior

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #21 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now, the match type is supported, following the [ANSI standard](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#match-type).

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
